### PR TITLE
Update MimeDir.php

### DIFF
--- a/libraries/Sabre/VObject/Parser/MimeDir.php
+++ b/libraries/Sabre/VObject/Parser/MimeDir.php
@@ -329,15 +329,17 @@ class MimeDir extends Parser {
 
                 $value = $this->unescapeParam($value);
 
-                if (is_null($property['parameters'][$lastParam])) {
-                    $property['parameters'][$lastParam] = $value;
-                } elseif (is_array($property['parameters'][$lastParam])) {
-                    $property['parameters'][$lastParam][] = $value;
-                } else {
-                    $property['parameters'][$lastParam] = array(
-                        $property['parameters'][$lastParam],
-                        $value
-                    );
+                if(isset($property['parameters'][$lastParam])) {
+                    if (is_null($property['parameters'][$lastParam])) {
+                        $property['parameters'][$lastParam] = $value;
+                    } elseif (is_array($property['parameters'][$lastParam])) {
+                        $property['parameters'][$lastParam][] = $value;
+                    } else {
+                        $property['parameters'][$lastParam] = array(
+                            $property['parameters'][$lastParam],
+                            $value
+                        );
+                    }
                 }
                 continue;
             }


### PR DESCRIPTION
Sometimes $lastParam is empty, which causes php to emit an error which stops the normal dataflow.
In this case, a popup stating that there was an error during message sending is shown, while actually the message is correctly sent.
This prevents the user from receiving wrong information.
