### PR TITLE
fix(settings.xml) password set on fresh install.

### DIFF
--- a/data/settings/settings.xml
+++ b/data/settings/settings.xml
@@ -4,7 +4,7 @@
 		<SiteName>AfterLogic WebMail Lite</SiteName>
 		<LicenseKey />
 		<AdminLogin>mailadm</AdminLogin>
-		<AdminPassword>12345</AdminPassword>
+		<AdminPassword />
 		<DBType>MySQL</DBType>
 		<DBPrefix />
 		<DBHost />


### PR DESCRIPTION
The password on a fresh install was set to 12345 in plain text in the settings.xml file this should be set to an empty <AdminPassword /> because this expects to either be empty or have a password hash. When empty the default password is 12345.

Regards to this issue #51 