### PR TITLE
Fixed integrator managers call to webmail manager where username only…

### DIFF
--- a/libraries/afterlogic/common/managers/integrator/manager.php
+++ b/libraries/afterlogic/common/managers/integrator/manager.php
@@ -746,6 +746,12 @@ class CApiIntegratorManager extends AApiManager
 		$bAuthResult = false;
 		CApi::Plugin()->RunHook('api-integrator-login-to-account', array(&$sEmail, &$sIncPassword, &$sIncLogin, &$sLanguage, &$bAuthResult));
 
+        // where only username is used for login, need to use the appropriate lookup
+        if (0 === strlen($sEmail))
+        {
+            $sEmail = $sIncLogin;
+        }
+            
 		$oAccount = $oApiUsersManager->getAccountByEmail($sEmail);
 		if ($oAccount instanceof CAccount)
 		{


### PR DESCRIPTION
… logins were ignored and a fully qualified email was always expected.

In the case where the user would use only a username for login, the integrator manager was ignoring this scenario and was only plumbing through the email variable. I've changed the behaviour to check that if there was no email provided then we would use the value form the login variable.