### PR TITLE
Create .htaccess

### DIFF
--- a/data/settings/.htaccess
+++ b/data/settings/.htaccess
@@ -1,0 +1,1 @@
+Deny from all


### PR DESCRIPTION
Add Deny from all.
Without this file present, anyone can view the database settings located in settings.xml & settings.xml.bak
Thou Apache 2.4 will Error 500 because of the directive changes. Its a better solution than allowing http access to the contents.

Likely to be abused by exploit crawlers